### PR TITLE
Add Mastodon verifiable link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "themes/ananke"]
 	path = themes/ananke
-	url = https://github.com/budparr/gohugo-theme-ananke.git
+	url = https://github.com/adambkaplan/gohugo-theme-ananke.git

--- a/config.toml
+++ b/config.toml
@@ -23,12 +23,26 @@ enableRobotsTXT = true
 [params]
   favicon = "images/icons/favicon.ico"
   description = ""
-  facebook = ""
-  twitter = "https://twitter.com/adambkaplan"
-  instagram = ""
-  youtube = ""
-  linkedin = "https://linkedin.com/in/adambkaplan"
-  github = "https://github.com/adambkaplan"
   # choose a background color from any on this page: http://tachyons.io/docs/themes/skins/ and preface it with "bg-"
   background_color_class = "bg-silver"
   featured_image = "/images/mouna_loa_sunset.JPG"
+
+  [[params.ananke_socials]]
+    name = "linkedin"
+    url = "https://linkedin.com/in/adambkaplan"
+    verify = true
+
+  [[params.ananke_socials]]
+    name = "twitter"
+    url = "https://twitter.com/adambkaplan"
+    verify = true
+
+  [[params.ananke_socials]]
+    name = "mastodon"
+    url = "https://hachyderm.io/@adambkaplan"
+    verify = true
+
+  [[params.ananke_socials]]
+    name = "github"
+    url = "https://github.com/adambkaplan"
+    verify = true


### PR DESCRIPTION
- Add social link for Mastodon, fix to use new TOML config for social links.
- Use my fork of the theme to include `rel="me"` links